### PR TITLE
[FEAT] 자주 사용하는 계획 등록 API

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -6,7 +6,6 @@ import { ScheduleCreateDto } from '../interfaces/schedule/ScheduleCreateDto';
 import ScheduleService from '../services/ScheduleService';
 import mongoose from 'mongoose';
 import { ScheduleUpdateDto } from '../interfaces/schedule/ScheduleUpdateDto';
-import Schedule from '../models/Schedule';
 
 /**
  * @route POST /schedule
@@ -188,10 +187,54 @@ const updateScheduleTitle = async (req: Request, res: Response) => {
   }
 };
 
+/**
+ * @route POST /schedule/day-routine
+ * @desc Create Routine with Schedule
+ * @access Public
+ */
+const createRoutine = async (req: Request, res: Response) => {
+  let { scheduleId } = req.body;
+  if (!scheduleId || scheduleId.length != 24) {
+    // 유효하지 않은 scheduleId인 경우 : 400 error
+    return res
+      .status(statusCode.BAD_REQUEST)
+      .send(util.fail(statusCode.BAD_REQUEST, message.NULL_VALUE));
+  }
+
+  scheduleId = new mongoose.Types.ObjectId(scheduleId);
+  const userId = new mongoose.Types.ObjectId('62cd27ae39f42cfbf520009a');
+
+  try {
+    const newRoutine = await ScheduleService.createRoutine(userId, scheduleId);
+
+    if (!newRoutine) {
+      // newRoutine으로 null이 반환 된 경우(scheduleId에 해당하는 원본 계획블록이 없는 경우) :  404 error
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND));
+    }
+
+    res
+      .status(statusCode.CREATED)
+      .send(util.success(statusCode.CREATED, message.CREATE_ROUTINE_SUCCESS));
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(
+        util.fail(
+          statusCode.INTERNAL_SERVER_ERROR,
+          message.INTERNAL_SERVER_ERROR
+        )
+      );
+  }
+};
+
 export default {
   createSchedule,
   dayReschedule,
   getDailySchedules,
   getReschedules,
   updateScheduleTitle,
+  createRoutine,
 };

--- a/src/interfaces/schedule/ScheduleCreateDto.ts
+++ b/src/interfaces/schedule/ScheduleCreateDto.ts
@@ -6,4 +6,6 @@ export interface ScheduleCreateDto {
   categoryColorCode: string;
   userId: mongoose.Types.ObjectId;
   orderIndex: Number;
+  isReschedule?: boolean;
+  isRoutine?: boolean;
 }

--- a/src/models/Schedule.ts
+++ b/src/models/Schedule.ts
@@ -5,7 +5,6 @@ const ScheduleSchema = new mongoose.Schema(
   {
     date: {
       type: String,
-      required: true,
     },
     timeSets: [
       {

--- a/src/modules/calculateOrderIndex.ts
+++ b/src/modules/calculateOrderIndex.ts
@@ -1,0 +1,16 @@
+import { ScheduleInfo } from '../interfaces/schedule/ScheduleInfo';
+
+export const calculateOrderIndex = (
+  originalSchedules: ScheduleInfo[]
+): number => {
+  let newIndex;
+  if (originalSchedules.length === 0) {
+    // 이미 존재하는 계획블록이 없을 경우, 해당 영역의 첫 번째 블록
+    newIndex = 1024;
+  } else {
+    // 계획블록이 이미 존재하는 경우, 기존 존재하는 계획블록의 마지막 index + 1024로 설정
+    newIndex = originalSchedules[originalSchedules.length - 1].orderIndex;
+    newIndex += 1024;
+  }
+  return newIndex;
+};

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -16,6 +16,7 @@ const message = {
   GET_RESCHEDULES_SUCCESS: '미룬 계획블록 리스트 조회 성공',
   GET_DAILY_INFORMATION_SUCCESS: '일간계획 정보 조회 성공',
   UPDATE_SCHEDULE_TITLE_SUCCESS: '계획블록 이름 수정 성공',
+  CREATE_ROUTINE_SUCCESS: '자주 사용하는 계획 등록 성공',
 };
 
 export default message;

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -8,5 +8,6 @@ router.patch('/day-reschedule', ScheduleController.dayReschedule);
 router.get('/days', ScheduleController.getDailySchedules);
 router.get('/delay', ScheduleController.getReschedules);
 router.patch('/title', ScheduleController.updateScheduleTitle);
+router.post('/day-routine', ScheduleController.createRoutine);
 
 export default router;

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -5,6 +5,7 @@ import { ScheduleListGetDto } from '../interfaces/schedule/ScheduleListGetDto';
 import { RescheduleListGetDto } from '../interfaces/schedule/RescheduleListGetDto';
 import { ScheduleUpdateDto } from '../interfaces/schedule/ScheduleUpdateDto';
 import { ScheduleInfo } from '../interfaces/schedule/ScheduleInfo';
+import { calculateOrderIndex } from '../modules/calculateOrderIndex';
 
 const createSchedule = async (
   scheduleCreateDto: ScheduleCreateDto
@@ -132,17 +133,7 @@ const createRoutine = async (
       isRoutine: true,
       userId: userId,
     }).sort({ orderIndex: 1 });
-
-    // 새로 생성할 계획블록의 index 계산
-    let newIndex;
-    if (existingRoutines.length === 0) {
-      // 이미 존재하는 계획블록이 없을 경우, 해당 날짜의 첫 번째 블록
-      newIndex = 1024;
-    } else {
-      // 계획블록이 이미 존재하는 경우, 기존 존재하는 계획블록의 마지막 index + 1024로 설정
-      newIndex = existingRoutines[existingRoutines.length - 1].orderIndex;
-      newIndex += 1024;
-    }
+    const newIndex = calculateOrderIndex(existingRoutines);
 
     // 새로운 routine 생성
     const newSchedule: ScheduleCreateDto = {

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -11,22 +11,12 @@ const createSchedule = async (
   scheduleCreateDto: ScheduleCreateDto
 ): Promise<void> => {
   try {
-    // 이미 존재하는 계획블록 조회 (orderIndex로 정렬)
+    // 특정 날짜의 계획블록 영억 내에서의 orderIndex 계산
     const existingSchedules = await Schedule.find({
       date: scheduleCreateDto.date,
       userId: scheduleCreateDto.userId,
     }).sort({ orderIndex: 1 });
-
-    // 새로 생성할 계획블록의 index 계산
-    let newIndex;
-    if (existingSchedules.length === 0) {
-      // 이미 존재하는 계획블록이 없을 경우, 해당 날짜의 첫 번째 블록
-      newIndex = 1024;
-    } else {
-      // 계획블록이 이미 존재하는 경우, 기존 존재하는 계획블록의 마지막 index + 1024로 설정
-      newIndex = existingSchedules[existingSchedules.length - 1].orderIndex;
-      newIndex += 1024;
-    }
+    const newIndex = calculateOrderIndex(existingSchedules);
 
     // scheduleCreateDto에 orderIndex 삽입
     scheduleCreateDto.orderIndex = newIndex;


### PR DESCRIPTION
close #32 

- 자주 사용하는 계획 등록 responseMessage 추가
- Schedule model date 속성 required 삭제
- 자주 사용하는 계획 등록 Router - Controller 연결
- ScheduleCreateDto에 isReschedule, isRoutine nullable field 추가
- 자주 사용하는 계획 등록 Controller 구현
- 자주 사용하는 계획 등록 Service 구현
- orderIndex 계산 로직 모듈화
- 자주 사용하는 계획 등록 orderIndex 모듈화 적용
- 계획 블록 생성 orderIndex 모듈화 적용