### PR TITLE
[FEAT] 자주 사용하는 계획 조회 API

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -230,6 +230,33 @@ const createRoutine = async (req: Request, res: Response) => {
   }
 };
 
+/**
+ * @route GET /schedule/routine
+ * @desc Get Routines
+ * @access Public
+ */
+const getRoutines = async (req: Request, res: Response) => {
+  const userId = new mongoose.Types.ObjectId('62cd27ae39f42cfbf520009a');
+  try {
+    const routines = await ScheduleService.getRoutines(userId);
+    res
+      .status(statusCode.OK)
+      .send(
+        util.success(statusCode.OK, message.GET_ROUTINES_SUCCESS, routines)
+      );
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(
+        util.fail(
+          statusCode.INTERNAL_SERVER_ERROR,
+          message.INTERNAL_SERVER_ERROR
+        )
+      );
+  }
+};
+
 export default {
   createSchedule,
   dayReschedule,
@@ -237,4 +264,5 @@ export default {
   getReschedules,
   updateScheduleTitle,
   createRoutine,
+  getRoutines,
 };

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -17,6 +17,7 @@ const message = {
   GET_DAILY_INFORMATION_SUCCESS: '일간계획 정보 조회 성공',
   UPDATE_SCHEDULE_TITLE_SUCCESS: '계획블록 이름 수정 성공',
   CREATE_ROUTINE_SUCCESS: '자주 사용하는 계획 등록 성공',
+  GET_ROUTINES_SUCCESS: '자주 사용하는 계획 조회 성공',
 };
 
 export default message;

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -9,5 +9,6 @@ router.get('/days', ScheduleController.getDailySchedules);
 router.get('/delay', ScheduleController.getReschedules);
 router.patch('/title', ScheduleController.updateScheduleTitle);
 router.post('/day-routine', ScheduleController.createRoutine);
+router.get('/routine', ScheduleController.getRoutines);
 
 export default router;

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -83,6 +83,7 @@ const getReschedules = async (
     throw error;
   }
 };
+
 const updateScheduleTitle = async (
   scheduleId: mongoose.Types.ObjectId,
   scheduleUpdateDto: ScheduleUpdateDto
@@ -144,6 +145,22 @@ const createRoutine = async (
   }
 };
 
+const getRoutines = async (
+  userId: mongoose.Types.ObjectId
+): Promise<ScheduleListGetDto> => {
+  try {
+    const routines = await Schedule.find({
+      userId: userId,
+      isRoutine: true,
+    }).sort({ orderIndex: 1 });
+
+    return { schedules: routines };
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
 export default {
   createSchedule,
   dayReschedule,
@@ -151,4 +168,5 @@ export default {
   getReschedules,
   updateScheduleTitle,
   createRoutine,
+  getRoutines,
 };


### PR DESCRIPTION
## Solved Issue
close #36 

<br>

## Motivation
- 자주 사용하는 계획을 조회하는 API를 구현합니다.

<br>

## Key Changes
- responseMessage 추가
- Router 연결
- Controller 구현
- Service 구현

<br>

## To Reviewers
- 미룬 계획 조회 API를 많이 참고해서 구현했습니다.
- 구현 중에 미룬 계획 / 자주 사용하는 계획 등록 시 subSchedules 처리가 되지 않았음을 발견했습니다. 추후 수정 예정입니다.