### PR TITLE
[FEAT] 미룬 계획블록 계획표로 옮기기 API

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -115,6 +115,7 @@ const getDailySchedules = async (req: Request, res: Response) => {
       );
   }
 };
+
 /**
  * @route GET /schedule/delay
  * @desc Get Reschedules
@@ -139,6 +140,7 @@ const getReschedules = async (req: Request, res: Response) => {
       );
   }
 };
+
 /**
  * @route PATCH /schedule/title
  * @desc Update Schedule Title
@@ -258,6 +260,42 @@ const getRoutines = async (req: Request, res: Response) => {
   }
 };
 
+/**
+ * @route PATCH /schedule/reschedule-day
+ * @desc Move Reschedule back to Schedules
+ * @access Public
+ */
+const rescheduleDay = async (req: Request, res: Response) => {
+  let { scheduleId } = req.body;
+  const { date } = req.body;
+  scheduleId = new mongoose.Types.ObjectId(scheduleId);
+  try {
+    const moveBackSchedule = await ScheduleService.rescheduleDay(
+      scheduleId,
+      date
+    );
+    if (!moveBackSchedule) {
+      // scheduleId가 잘못된 경우, 404 return
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND));
+    }
+    res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.MOVE_BACK_SCHEDULE_SUCCESS));
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(
+        util.fail(
+          statusCode.INTERNAL_SERVER_ERROR,
+          message.INTERNAL_SERVER_ERROR
+        )
+      );
+  }
+};
+
 export default {
   createSchedule,
   dayReschedule,
@@ -266,4 +304,5 @@ export default {
   updateScheduleTitle,
   createRoutine,
   getRoutines,
+  rescheduleDay,
 };

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -18,6 +18,7 @@ const message = {
   UPDATE_SCHEDULE_TITLE_SUCCESS: '계획블록 이름 수정 성공',
   CREATE_ROUTINE_SUCCESS: '자주 사용하는 계획 등록 성공',
   GET_ROUTINES_SUCCESS: '자주 사용하는 계획 조회 성공',
+  MOVE_BACK_SCHEDULE_SUCCESS: '미룬 계획블록 계획표로 옮기기 성공',
 };
 
 export default message;

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -10,5 +10,6 @@ router.get('/delay', ScheduleController.getReschedules);
 router.patch('/title', ScheduleController.updateScheduleTitle);
 router.post('/day-routine', ScheduleController.createRoutine);
 router.get('/routine', ScheduleController.getRoutines);
+router.patch('/reschedule-day', ScheduleController.rescheduleDay);
 
 export default router;

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -204,6 +204,45 @@ const getRoutines = async (
   }
 };
 
+const rescheduleDay = async (
+  scheduleId: mongoose.Types.ObjectId,
+  date: string
+): Promise<ScheduleInfo | null> => {
+  try {
+    // 계획블록의 isReschedule false로 전환, date 지정
+    const moveBackSchedule = await Schedule.findOneAndUpdate(
+      {
+        _id: scheduleId,
+      },
+      {
+        $set: { isReschedule: false, date: date },
+      },
+      { new: true }
+    );
+
+    if (!moveBackSchedule) {
+      return null;
+    } else {
+      // 하위 계획블록도 동일하게 처리
+      for (const moveBackSubSchedule of moveBackSchedule.subSchedules) {
+        await Schedule.findOneAndUpdate(
+          {
+            _id: moveBackSubSchedule._id,
+          },
+          {
+            $set: { isReschedule: false, date: date },
+          },
+          { new: true }
+        );
+      }
+    }
+    return moveBackSchedule;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
 export default {
   createSchedule,
   dayReschedule,
@@ -212,4 +251,5 @@ export default {
   updateScheduleTitle,
   createRoutine,
   getRoutines,
+  rescheduleDay,
 };


### PR DESCRIPTION
## Solved Issue
close #42 

<br>

## Motivation
- 미룬 계획블록을 다시 계획표로 옮기는 API를 구현합니다.

<br>

## Key Changes
- responseMessage 추가
- Router 연결
- Controller 구현
- Service 구현

<br>

## To Reviewers
- 계획블록 미루기와 상당히 유사해서 빠르게 만들 수 있었습니다 ㅎㅎ
