### PR TITLE
[FEAT] 자주 사용하는 계획블록 계획표로 옮기기 API

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -295,7 +295,43 @@ const rescheduleDay = async (req: Request, res: Response) => {
       );
   }
 };
-
+/**
+ * @route PATCH /schedule/reschedule-day
+ * @desc Move Routine back to Schedules
+ * @access Public
+ */
+const routineDay = async (req: Request, res: Response) => {
+  let { scheduleId } = req.body;
+  const { date } = req.body;
+  scheduleId = new mongoose.Types.ObjectId(scheduleId);
+  try {
+    const moveRoutineToSchedule = await ScheduleService.routineDay(
+      scheduleId,
+      date
+    );
+    if (!moveRoutineToSchedule) {
+      // scheduleId가 잘못된 경우, 404 return
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND));
+    }
+    res
+      .status(statusCode.OK)
+      .send(
+        util.success(statusCode.OK, message.MOVE_ROUTINE_TO_SCHEDULE_SUCCESS)
+      );
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(
+        util.fail(
+          statusCode.INTERNAL_SERVER_ERROR,
+          message.INTERNAL_SERVER_ERROR
+        )
+      );
+  }
+};
 export default {
   createSchedule,
   dayReschedule,
@@ -305,4 +341,5 @@ export default {
   createRoutine,
   getRoutines,
   rescheduleDay,
+  routineDay,
 };

--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -296,16 +296,25 @@ const rescheduleDay = async (req: Request, res: Response) => {
   }
 };
 /**
- * @route PATCH /schedule/reschedule-day
+ * @route POST /schedule/reschedule-day
  * @desc Move Routine back to Schedules
  * @access Public
  */
 const routineDay = async (req: Request, res: Response) => {
   let { scheduleId } = req.body;
   const { date } = req.body;
+  if (!scheduleId || scheduleId.length != 24) {
+    // 유효하지 않은 scheduleId인 경우 : 400 error
+    return res
+      .status(statusCode.BAD_REQUEST)
+      .send(util.fail(statusCode.BAD_REQUEST, message.NULL_VALUE));
+  }
+
   scheduleId = new mongoose.Types.ObjectId(scheduleId);
+  const userId = new mongoose.Types.ObjectId('62cd27ae39f42cfbf520009a');
   try {
     const moveRoutineToSchedule = await ScheduleService.routineDay(
+      userId,
       scheduleId,
       date
     );

--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -297,7 +297,7 @@ const rescheduleDay = async (req: Request, res: Response) => {
 };
 /**
  * @route POST /schedule/reschedule-day
- * @desc Move Routine back to Schedules
+ * @desc Move Routine to Schedules
  * @access Public
  */
 const routineDay = async (req: Request, res: Response) => {

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -11,6 +11,7 @@ const message = {
 
   // Schedule
   CREATE_SCHEDULE_SUCCESS: '계획블록 생성 성공',
+  COMPLETE_SCHEDULE_SUCCESS: '계획블록 완료 성공',
   DELAY_SCHEDULE_SUCCESS: '계획블록 미루기 성공',
   GET_DAILY_SCHEDULES_SUCCESS: '일간 계획블록 리스트 조회 성공',
   GET_RESCHEDULES_SUCCESS: '미룬 계획블록 리스트 조회 성공',
@@ -19,6 +20,8 @@ const message = {
   CREATE_ROUTINE_SUCCESS: '자주 사용하는 계획 등록 성공',
   GET_ROUTINES_SUCCESS: '자주 사용하는 계획 조회 성공',
   MOVE_BACK_SCHEDULE_SUCCESS: '미룬 계획블록 계획표로 옮기기 성공',
+  MOVE_ROUTINE_TO_SCHEDULE_SUCCESS:
+    '자주 사용하는 계획블록 계획표로 옮기기 성공',
 };
 
 export default message;

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -11,5 +11,6 @@ router.patch('/title', ScheduleController.updateScheduleTitle);
 router.post('/day-routine', ScheduleController.createRoutine);
 router.get('/routine', ScheduleController.getRoutines);
 router.patch('/reschedule-day', ScheduleController.rescheduleDay);
+router.patch('/routine-day', ScheduleController.routineDay);
 
 export default router;

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -11,6 +11,6 @@ router.patch('/title', ScheduleController.updateScheduleTitle);
 router.post('/day-routine', ScheduleController.createRoutine);
 router.get('/routine', ScheduleController.getRoutines);
 router.patch('/reschedule-day', ScheduleController.rescheduleDay);
-router.patch('/routine-day', ScheduleController.routineDay);
+router.post('/routine-day', ScheduleController.routineDay);
 
 export default router;

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -249,7 +249,7 @@ const routineDay = async (
   date: string
 ): Promise<ScheduleInfo | null> => {
   try {
-    //계획표로 이동할 자주 사용하는 계획블록 find
+    // 계획표로 이동할 자주 사용하는 계획블록 find
     const moveRoutineToSchedule = await Schedule.findById(scheduleId).populate({
       path: 'subSchedules',
       model: 'Schedule',
@@ -272,7 +272,6 @@ const routineDay = async (
       categoryColorCode: moveRoutineToSchedule.categoryColorCode,
       userId: moveRoutineToSchedule.userId,
       orderIndex: newIndex,
-      //isRoutine: false,
       subSchedules: [],
     };
 

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -6,7 +6,6 @@ import { RescheduleListGetDto } from '../interfaces/schedule/RescheduleListGetDt
 import { ScheduleUpdateDto } from '../interfaces/schedule/ScheduleUpdateDto';
 import { ScheduleInfo } from '../interfaces/schedule/ScheduleInfo';
 import { calculateOrderIndex } from '../modules/calculateOrderIndex';
-import { check } from 'express-validator';
 
 const createSchedule = async (
   scheduleCreateDto: ScheduleCreateDto
@@ -245,38 +244,62 @@ const rescheduleDay = async (
 };
 
 const routineDay = async (
+  userId: mongoose.Types.ObjectId,
   scheduleId: mongoose.Types.ObjectId,
   date: string
 ): Promise<ScheduleInfo | null> => {
   try {
-    // 계획블록의 isRoutine false로 전환, date 지정
-    const moveRoutineToSchedule = await Schedule.findOneAndUpdate(
-      {
-        _id: scheduleId,
-      },
-      {
-        $set: { isRoutine: false, date: date },
-      },
-      { new: true }
-    );
-
+    //계획표로 이동할 자주 사용하는 계획블록 find
+    const moveRoutineToSchedule = await Schedule.findById(scheduleId).populate({
+      path: 'subSchedules',
+      model: 'Schedule',
+    });
     if (!moveRoutineToSchedule) {
-      return null;
-    } else {
-      // 하위 계획블록도 동일하게 처리
-      for (const moveBackSubSchedule of moveRoutineToSchedule.subSchedules) {
-        await Schedule.findOneAndUpdate(
-          {
-            _id: moveBackSubSchedule._id,
-          },
-          {
-            $set: { isRoutine: false, date: date },
-          },
-          { new: true }
-        );
-      }
+      // scheduleId에 해당하는 원본 계획블록이 없는 경우, null을 return
+      return moveRoutineToSchedule;
     }
-    return moveRoutineToSchedule;
+
+    // 계획표 내에서 orderIndex 계산
+    const existingSchedules = await Schedule.find({
+      date: date,
+      userId: userId,
+    }).sort({ orderIndex: 1 });
+    const newIndex = calculateOrderIndex(existingSchedules);
+    // 새로운 계획블록 생성
+    const newSchedule: ScheduleCreateDto = {
+      date: date,
+      title: moveRoutineToSchedule.title,
+      categoryColorCode: moveRoutineToSchedule.categoryColorCode,
+      userId: moveRoutineToSchedule.userId,
+      orderIndex: newIndex,
+      //isRoutine: false,
+      subSchedules: [],
+    };
+
+    // 자주 사용하는 계획블록의 하위 계획들을 복사해 newSubSchedules 생성
+    const newSubSchedules = await Promise.all(
+      moveRoutineToSchedule.subSchedules.map((RoutineSubSchedule: any) => {
+        const result = {
+          date: date,
+          title: RoutineSubSchedule.title,
+          categoryColorCode: RoutineSubSchedule.categoryColorCode,
+          userId: RoutineSubSchedule.userId,
+          orderIndex: RoutineSubSchedule.orderIndex,
+          isRoutine: false,
+        };
+        return result;
+      })
+    );
+    // newSubSchedules 배열을 돌면서 후속 처리 진행
+    for (const newSubSchedule of newSubSchedules) {
+      const newSubFromRoutine = new Schedule(newSubSchedule); // Schedule 객체인 newSubFromRoutine 생성
+      await newSubFromRoutine.save(); // 생성된 newSubFromRoutine을 db에 저장
+      newSchedule.subSchedules?.push(newSubFromRoutine._id); // 생성된 newSubFromRoutine의 _id를 newSchedule의 subSchedule 배열에 삽입
+    }
+
+    const makeNewSchedule = new Schedule(newSchedule); // 하위 계획의 후속처리까지 완료된 새로 생성된 자주 사용하는 계획을 Schedule 객체로 생성
+    await makeNewSchedule.save(); // 생성된 newRoutine을 db에 저장
+    return makeNewSchedule;
   } catch (error) {
     console.log(error);
     throw error;

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -272,6 +272,7 @@ const routineDay = async (
       categoryColorCode: moveRoutineToSchedule.categoryColorCode,
       userId: moveRoutineToSchedule.userId,
       orderIndex: newIndex,
+      isRoutine: false,
       subSchedules: [],
     };
 


### PR DESCRIPTION
## Solved Issue
close #39 

<br>

## Motivation
- 자주 사용하는 계획블록을 계획표로 옮기는 API 구현합니다.

<br>

## Key Changes
- responseMessage 추가
- Controller 구현
- Service 구현
- Router 구현

<br>

## To Reviewers
- 미룬 계획블록 계획표로 옮기는 API와 flag만 달라서 빠르게 제작할 수 있었습니다!
- 몸 상태 괜찮아지면 코드리뷰 해주세요! 아프지 않았으면 좋겠습니다:)
-  하위계획이 3개인 더미데이터로 test했는데 newSubSchedule 생성하는 로직에서 map 돌릴 때 2개밖에 안들어가네요.. 나중에 봐주시면 감사하겠습니다..!