### PR TITLE
[FEAT] 계획블록 순서 변경 API

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -115,6 +115,7 @@ const getDailySchedules = async (req: Request, res: Response) => {
       );
   }
 };
+
 /**
  * @route PATCH /schedule/complete
  * @desc Complete Schedule
@@ -336,6 +337,7 @@ const rescheduleDay = async (req: Request, res: Response) => {
       );
   }
 };
+
 /**
  * @route POST /schedule/reschedule-day
  * @desc Move Routine to Schedules
@@ -382,6 +384,50 @@ const routineDay = async (req: Request, res: Response) => {
       );
   }
 };
+
+/**
+ * @route PATCH /schedule/order
+ * @desc Reorder Schedules
+ * @access Public
+ */
+const updateScheduleOrder = async (req: Request, res: Response) => {
+  let { scheduleId } = req.body;
+  const { movedScheduleArray } = req.body;
+
+  if (!scheduleId || scheduleId.length != 24) {
+    // 유효하지 않은 scheduleId인 경우 : 400 error
+    return res
+      .status(statusCode.BAD_REQUEST)
+      .send(util.fail(statusCode.BAD_REQUEST, message.NULL_VALUE));
+  }
+
+  try {
+    const updatedSchedule = await ScheduleService.updateScheduleOrder(
+      scheduleId,
+      movedScheduleArray
+    );
+    if (!updatedSchedule) {
+      // scheduleId가 잘못된 경우, 404 return
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND));
+    }
+    res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.UPDATE_SCHEDULE_ORDER_SUCCESS));
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(
+        util.fail(
+          statusCode.INTERNAL_SERVER_ERROR,
+          message.INTERNAL_SERVER_ERROR
+        )
+      );
+  }
+};
+
 export default {
   createSchedule,
   completeSchedule,
@@ -393,4 +439,5 @@ export default {
   getRoutines,
   rescheduleDay,
   routineDay,
+  updateScheduleOrder,
 };

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -22,6 +22,7 @@ const message = {
   MOVE_BACK_SCHEDULE_SUCCESS: '미룬 계획블록 계획표로 옮기기 성공',
   MOVE_ROUTINE_TO_SCHEDULE_SUCCESS:
     '자주 사용하는 계획블록 계획표로 옮기기 성공',
+  UPDATE_SCHEDULE_ORDER_SUCCESS: '계획블록 순서 변경 성공',
 };
 
 export default message;

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -13,5 +13,6 @@ router.post('/day-routine', ScheduleController.createRoutine);
 router.get('/routine', ScheduleController.getRoutines);
 router.patch('/reschedule-day', ScheduleController.rescheduleDay);
 router.post('/routine-day', ScheduleController.routineDay);
+router.patch('/order', ScheduleController.updateScheduleOrder);
 
 export default router;

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -344,6 +344,64 @@ const routineDay = async (
   }
 };
 
+const updateScheduleOrder = async (
+  scheduleId: string,
+  movedScheduleArray: string[]
+): Promise<ScheduleInfo | null> => {
+  // 순서 변경 이후 상태의 계획블록 ID들의 배열에서 변경된 계획블록 탐색
+  let movedScheduleIndex;
+  movedScheduleArray.forEach((movedScheduleId: string, index: number) => {
+    if (movedScheduleId === scheduleId) {
+      movedScheduleIndex = index;
+    }
+  });
+
+  try {
+    // 새로운 orderIndex 계산
+    let previousSchedule;
+    let nextSchedule;
+    let newOrderIndex;
+    if (movedScheduleIndex === 0) {
+      // 이동 후 계획블록이 영역의 맨 위에 위치할 때 : 기존 맨 위의 orderIndex / 2
+      nextSchedule = await Schedule.findById(
+        movedScheduleArray[movedScheduleIndex + 1]
+      );
+      newOrderIndex = nextSchedule!.orderIndex / 2; // nullable 제거 위해 타입 단언
+    } else if (movedScheduleIndex === movedScheduleArray.length - 1) {
+      // 이동 후 계획블록이 영역의 맨 아래에 위치할 때 : 기존 맨 아래의 orderIndex + 1024
+      previousSchedule = await Schedule.findById(
+        movedScheduleArray[movedScheduleIndex - 1]
+      );
+      newOrderIndex = previousSchedule!.orderIndex + 1024;
+    } else if (movedScheduleIndex) {
+      // undefined 방지 위해 else if 안에서 진행
+      previousSchedule = await Schedule.findById(
+        movedScheduleArray[movedScheduleIndex - 1]
+      );
+      nextSchedule = await Schedule.findById(
+        movedScheduleArray[movedScheduleIndex + 1]
+      );
+      newOrderIndex =
+        (previousSchedule!.orderIndex + nextSchedule!.orderIndex) / 2;
+    }
+
+    // 기존 계획블록의 orderIndex 변경
+    const updatedSchedule = await Schedule.findOneAndUpdate(
+      {
+        _id: scheduleId,
+      },
+      {
+        orderIndex: newOrderIndex,
+      },
+      { new: true }
+    );
+    return updatedSchedule;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
 export default {
   createSchedule,
   completeSchedule,
@@ -355,4 +413,5 @@ export default {
   getRoutines,
   rescheduleDay,
   routineDay,
+  updateScheduleOrder,
 };


### PR DESCRIPTION
## Solved Issue
close #44

<br>

## Motivation
- 계획블록 영역 내에서 계획블록의 순서를 변경하는 API를 구현합니다.

<br>

## Key Changes
- responseMessage 추가
- Router - Controller 구현
- Controller 구현
- Service 구현

<br>

## To Reviewers
- 주석 잘 따라가면서 확인하시면 됩니다!
