### PR TITLE
[FIX] 계획블록 이름 수정 API ScheduleId request로 받도록 수정

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -189,9 +189,7 @@ const getReschedules = async (req: Request, res: Response) => {
  * @access Public
  */
 const updateScheduleTitle = async (req: Request, res: Response) => {
-  // let { scheduleId } = req.body; // 이후에 scheduleId까지 받기
-  const { newTitle } = req.body;
-  const scheduleId = new mongoose.Types.ObjectId('62cd876a77bc33d906978333');
+  const { scheduleId, newTitle } = req.body;
 
   if (!scheduleId || !newTitle) {
     return res


### PR DESCRIPTION
## Solved Issue
close #50 

<br>

## Motivation
- 계획블록 이름 수정 API에 현재 scheduleId가 명시적으로 지정되어 있었음
- DB 구조 변경으로 인한 콜렉션 삭제로 코드 변경 필요

<br>

## Key Changes
- 코드 내에 삽입 된 scheduleId 삭제
- request body로 scheduleId 획득

<br>

## To Reviewers
- 간단한 수정이니 확인 후 바로 머지 부탁드립니다!
