### PR TITLE
[FEAT] 계획블록 카테고리 변경 API

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -426,6 +426,53 @@ const updateScheduleOrder = async (req: Request, res: Response) => {
   }
 };
 
+/**
+ * @route PATCH /schedule/category
+ * @desc Update Schedule Category Color Code
+ * @access Public
+ */
+const updateScheduleCategory = async (req: Request, res: Response) => {
+  const { scheduleId, newCategoryColorCode } = req.body;
+
+  if (!scheduleId || !newCategoryColorCode) {
+    return res
+      .status(statusCode.BAD_REQUEST)
+      .send(util.fail(statusCode.BAD_REQUEST, message.NULL_VALUE));
+  }
+
+  const scheduleUpdateDto: ScheduleUpdateDto = {
+    categoryColorCode: newCategoryColorCode,
+  };
+
+  try {
+    const updatedSchedule = await ScheduleService.updateScheduleCategory(
+      scheduleId,
+      scheduleUpdateDto
+    );
+    if (!updatedSchedule) {
+      // scheduleId가 잘못된 경우, 404 return
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND));
+    }
+    res
+      .status(statusCode.OK)
+      .send(
+        util.success(statusCode.OK, message.UPDATE_SCHEDULE_CATEGORY_SUCCESS)
+      );
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(
+        util.fail(
+          statusCode.INTERNAL_SERVER_ERROR,
+          message.INTERNAL_SERVER_ERROR
+        )
+      );
+  }
+};
+
 export default {
   createSchedule,
   completeSchedule,
@@ -438,4 +485,5 @@ export default {
   rescheduleDay,
   routineDay,
   updateScheduleOrder,
+  updateScheduleCategory,
 };

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -23,6 +23,7 @@ const message = {
   MOVE_ROUTINE_TO_SCHEDULE_SUCCESS:
     '자주 사용하는 계획블록 계획표로 옮기기 성공',
   UPDATE_SCHEDULE_ORDER_SUCCESS: '계획블록 순서 변경 성공',
+  UPDATE_SCHEDULE_CATEGORY_SUCCESS: '계획블록 카테고리 변경 성공',
 };
 
 export default message;

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -14,5 +14,6 @@ router.get('/routine', ScheduleController.getRoutines);
 router.patch('/reschedule-day', ScheduleController.rescheduleDay);
 router.post('/routine-day', ScheduleController.routineDay);
 router.patch('/order', ScheduleController.updateScheduleOrder);
+router.patch('/category', ScheduleController.updateScheduleCategory);
 
 export default router;

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -402,6 +402,28 @@ const updateScheduleOrder = async (
   }
 };
 
+const updateScheduleCategory = async (
+  scheduleId: string,
+  scheduleUpdateDto: ScheduleUpdateDto
+): Promise<ScheduleInfo | null> => {
+  try {
+    const updatedSchedule = await Schedule.findOneAndUpdate(
+      {
+        _id: scheduleId,
+      },
+      {
+        categoryColorCode: scheduleUpdateDto.categoryColorCode,
+      },
+      { new: true }
+    );
+
+    return updatedSchedule;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
 export default {
   createSchedule,
   completeSchedule,
@@ -414,4 +436,5 @@ export default {
   rescheduleDay,
   routineDay,
   updateScheduleOrder,
+  updateScheduleCategory,
 };


### PR DESCRIPTION
## Solved Issue
close #53 

<br>

## Motivation
- 계획블록의 카테고리를 변경하는 API를 구현합니다.

<br>

## Key Changes
- responseMessage 추가
- Router - Controller 연결
- Controller 구현
- Service 구현

<br>

## To Reviewers
- 계획블록 제목 수정과 거의 비슷해 빠르게 구현했습니다. 확인 후 바로 머지 부탁드립니다.
