### PR TITLE
[FEAT] 계획블록 시간 삭제 API

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -82,6 +82,42 @@ const createTime = async (req: Request, res: Response) => {
 };
 
 /**
+ * @route Delete /schedule/time
+ * @desc Delete Schedule Time
+ * @access Public
+ */
+const deleteTime = async (req: Request, res: Response) => {
+  let { scheduleId } = req.body;
+  const timeDto: TimeDto = req.body;
+  scheduleId = new mongoose.Types.ObjectId(scheduleId);
+  try {
+    const deleteScheduleTime = await ScheduleService.deleteTime(
+      scheduleId,
+      timeDto
+    );
+    if (!deleteScheduleTime) {
+      // scheduleId가 잘못된 경우, 404 return
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND));
+    }
+    res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.DELETE_SCHEDULE_TIME_SUCCESS));
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(
+        util.fail(
+          statusCode.INTERNAL_SERVER_ERROR,
+          message.INTERNAL_SERVER_ERROR
+        )
+      );
+  }
+};
+
+/**
  * @route PATCH /schedule/day-reschedule
  * @desc Delay Schedule
  * @access Public
@@ -515,6 +551,7 @@ const updateScheduleCategory = async (req: Request, res: Response) => {
 export default {
   createSchedule,
   createTime,
+  deleteTime,
   completeSchedule,
   dayReschedule,
   getDailySchedules,

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -12,6 +12,7 @@ const message = {
   // Schedule
   CREATE_SCHEDULE_SUCCESS: '계획블록 생성 성공',
   CREATE_SCHEDULE_TIME_SUCCESS: '계획블록 시간 생성 성공',
+  DELETE_SCHEDULE_TIME_SUCCESS: '계획블록 시간 삭제 성공',
   COMPLETE_SCHEDULE_SUCCESS: '계획블록 완료 성공',
   DELAY_SCHEDULE_SUCCESS: '계획블록 미루기 성공',
   GET_DAILY_SCHEDULES_SUCCESS: '일간 계획블록 리스트 조회 성공',

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -5,6 +5,7 @@ const router: Router = Router();
 
 router.post('/', ScheduleController.createSchedule);
 router.post('/time', ScheduleController.createTime);
+router.delete('/time', ScheduleController.deleteTime);
 router.patch('/complete', ScheduleController.completeSchedule);
 router.patch('/day-reschedule', ScheduleController.dayReschedule);
 router.get('/days', ScheduleController.getDailySchedules);

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -73,6 +73,47 @@ const createTime = async (
   }
 };
 
+const deleteTime = async (
+  scheduleId: mongoose.Types.ObjectId,
+  timeDto: TimeDto
+): Promise<ScheduleInfo | null> => {
+  try {
+    const deleteScheduleTime = await Schedule.findById(scheduleId);
+    if (!deleteScheduleTime) {
+      return null;
+    } else {
+      if (timeDto.isUsed === false) {
+        await Schedule.findByIdAndUpdate(
+          {
+            _id: scheduleId,
+          },
+          {
+            $pull: { estimatedTime: { $in: timeDto.timeBlockNumbers } },
+          },
+          {
+            new: true,
+          }
+        );
+      } else {
+        await Schedule.findByIdAndUpdate(
+          {
+            _id: scheduleId,
+          },
+          {
+            $pull: { usedTime: { $in: timeDto.timeBlockNumbers } },
+          },
+          {
+            new: true,
+          }
+        );
+      }
+    }
+    return deleteScheduleTime;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
 const completeSchedule = async (
   scheduleId: mongoose.Types.ObjectId
 ): Promise<ScheduleInfo | null> => {
@@ -470,6 +511,7 @@ const updateScheduleCategory = async (
 export default {
   createSchedule,
   createTime,
+  deleteTime,
   completeSchedule,
   dayReschedule,
   getDailySchedules,


### PR DESCRIPTION
## Solved Issue
close #57 

<br>

## Motivation
-  계획블록 시간을 삭제합니다.

<br>

## Key Changes
- responseMessage 추가
- Service 구현
- Controller 구현
- Router-Controller 연결

<br>

## To Reviewers
- 계획블록 시간설정과 로직이 같아 빠르게 만들 수 있었습니다!  `pull`에서는 `$in` 연산자를 활용하여 여러 개를 한꺼번에 지울 수 있도록 구현했습니다!  확인 부탁드립니다:)
