### PR TITLE
[FEAT] 정보 작성 API

### DIFF
--- a/src/controllers/InformationController.ts
+++ b/src/controllers/InformationController.ts
@@ -6,18 +6,21 @@ import { InformationCreateDto } from '../interfaces/information/InformationCreat
 import InformationService from '../services/InformationService';
 
 /**
- * @route POST /information/memo
- * @desc Create Daily Memo
+ * @route POST /information/
+ * @desc Create Information
  * @access Public
  */
-const createDailyMemo = async (req: Request, res: Response) => {
-  const informationCreateDto: InformationCreateDto = req.body;
+const createInformation = async (req: Request, res: Response) => {
+  let informationCreateDto: InformationCreateDto = req.body;
+  informationCreateDto.userId = '62cd6eb82b6b4e92c7fc08f1';
   try {
-    await InformationService.createDailyMemo(informationCreateDto);
+    await InformationService.createInformation(informationCreateDto);
 
     res
       .status(statusCode.CREATED)
-      .send(util.success(statusCode.CREATED, message.CREATE_MEMO_SUCCESS));
+      .send(
+        util.success(statusCode.CREATED, message.CREATE_INFORMATION_SUCCESS)
+      );
   } catch (error) {
     console.log(error);
     res
@@ -63,66 +66,7 @@ const getDailyInformation = async (req: Request, res: Response) => {
   }
 };
 
-/**
- * @route POST /information/emoji
- * @desc Create Emoji
- * @access Public
- */
-const createEmoji = async (req: Request, res: Response) => {
-  const informationCreateDto: InformationCreateDto = req.body;
-  try {
-    await InformationService.createEmoji(informationCreateDto);
-
-    res
-      .status(statusCode.CREATED)
-      .send(util.success(statusCode.CREATED, message.CREATE_EMOJI_SUCCESS));
-  } catch (error) {
-    console.log(error);
-    res
-      .status(statusCode.INTERNAL_SERVER_ERROR)
-      .send(
-        util.fail(
-          statusCode.INTERNAL_SERVER_ERROR,
-          message.INTERNAL_SERVER_ERROR
-        )
-      );
-  }
-};
-
-/**
- * @route POST /information/days
- * @desc Create Daily Goal
- * @access Public
- */
-const createDailyGoal = async (req: Request, res: Response) => {
-  let informationCreateDto: InformationCreateDto = req.body;
-  informationCreateDto.userId = '62cd6eb82b6b4e92c7fc08f1';
-  informationCreateDto.type = 'dailyGoal';
-
-  try {
-    await InformationService.createDailyGoal(informationCreateDto);
-
-    res
-      .status(statusCode.CREATED)
-      .send(
-        util.success(statusCode.CREATED, message.CREATE_DAILY_GOAL_SUCCESS)
-      );
-  } catch (error) {
-    console.log(error);
-    res
-      .status(statusCode.INTERNAL_SERVER_ERROR)
-      .send(
-        util.fail(
-          statusCode.INTERNAL_SERVER_ERROR,
-          message.INTERNAL_SERVER_ERROR
-        )
-      );
-  }
-};
-
 export default {
-  createDailyMemo,
+  createInformation,
   getDailyInformation,
-  createEmoji,
-  createDailyGoal,
 };

--- a/src/controllers/InformationController.ts
+++ b/src/controllers/InformationController.ts
@@ -6,7 +6,7 @@ import { InformationCreateDto } from '../interfaces/information/InformationCreat
 import InformationService from '../services/InformationService';
 
 /**
- * @route POST /information/days
+ * @route POST /information/memo
  * @desc Create Daily Memo
  * @access Public
  */

--- a/src/controllers/InformationController.ts
+++ b/src/controllers/InformationController.ts
@@ -88,4 +88,41 @@ const createEmoji = async (req: Request, res: Response) => {
       );
   }
 };
-export default { createDailyMemo, getDailyInformation, createEmoji };
+
+/**
+ * @route POST /information/days
+ * @desc Create Daily Goal
+ * @access Public
+ */
+const createDailyGoal = async (req: Request, res: Response) => {
+  let informationCreateDto: InformationCreateDto = req.body;
+  informationCreateDto.userId = '62cd6eb82b6b4e92c7fc08f1';
+  informationCreateDto.type = 'dailyGoal';
+
+  try {
+    await InformationService.createDailyGoal(informationCreateDto);
+
+    res
+      .status(statusCode.CREATED)
+      .send(
+        util.success(statusCode.CREATED, message.CREATE_DAILY_GOAL_SUCCESS)
+      );
+  } catch (error) {
+    console.log(error);
+    res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(
+        util.fail(
+          statusCode.INTERNAL_SERVER_ERROR,
+          message.INTERNAL_SERVER_ERROR
+        )
+      );
+  }
+};
+
+export default {
+  createDailyMemo,
+  getDailyInformation,
+  createEmoji,
+  createDailyGoal,
+};

--- a/src/interfaces/information/InformationCreateDto.ts
+++ b/src/interfaces/information/InformationCreateDto.ts
@@ -1,8 +1,8 @@
 import mongoose from 'mongoose';
 
 export interface InformationCreateDto {
+  userId: string;
   date: string;
   type: string;
   value: string;
-  userId: mongoose.Types.ObjectId;
 }

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -6,7 +6,7 @@ const message = {
   INTERNAL_SERVER_ERROR: '서버 내부 오류',
 
   // Information
-  CREATE_INFORMATION_SUCCESS: '정보 생성 성공',
+  CREATE_INFORMATION_SUCCESS: '정보 작성 성공',
   GET_DAILY_INFORMATION_SUCCESS: '일간계획 정보 조회 성공',
 
   // Schedule

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -8,6 +8,7 @@ const message = {
   // Information
   CREATE_MEMO_SUCCESS: '하루 메모 작성 성공',
   CREATE_EMOJI_SUCCESS: '감정 이모티콘 설정 성공',
+  CREATE_DAILY_GOAL_SUCCESS: '일간 목표 작성 성공',
 
   // Schedule
   CREATE_SCHEDULE_SUCCESS: '계획블록 생성 성공',

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -9,6 +9,7 @@ const message = {
   CREATE_MEMO_SUCCESS: '하루 메모 작성 성공',
   CREATE_EMOJI_SUCCESS: '감정 이모티콘 설정 성공',
   CREATE_DAILY_GOAL_SUCCESS: '일간 목표 작성 성공',
+  GET_DAILY_INFORMATION_SUCCESS: '일간계획 정보 조회 성공',
 
   // Schedule
   CREATE_SCHEDULE_SUCCESS: '계획블록 생성 성공',
@@ -17,7 +18,6 @@ const message = {
   DELAY_SCHEDULE_SUCCESS: '계획블록 미루기 성공',
   GET_DAILY_SCHEDULES_SUCCESS: '일간 계획블록 리스트 조회 성공',
   GET_RESCHEDULES_SUCCESS: '미룬 계획블록 리스트 조회 성공',
-  GET_DAILY_INFORMATION_SUCCESS: '일간계획 정보 조회 성공',
   UPDATE_SCHEDULE_TITLE_SUCCESS: '계획블록 이름 수정 성공',
   CREATE_ROUTINE_SUCCESS: '자주 사용하는 계획 등록 성공',
   GET_ROUTINES_SUCCESS: '자주 사용하는 계획 조회 성공',

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -6,9 +6,7 @@ const message = {
   INTERNAL_SERVER_ERROR: '서버 내부 오류',
 
   // Information
-  CREATE_MEMO_SUCCESS: '하루 메모 작성 성공',
-  CREATE_EMOJI_SUCCESS: '감정 이모티콘 설정 성공',
-  CREATE_DAILY_GOAL_SUCCESS: '일간 목표 작성 성공',
+  CREATE_INFORMATION_SUCCESS: '정보 생성 성공',
   GET_DAILY_INFORMATION_SUCCESS: '일간계획 정보 조회 성공',
 
   // Schedule

--- a/src/routes/InformationRouter.ts
+++ b/src/routes/InformationRouter.ts
@@ -3,9 +3,7 @@ import { InformationController } from '../controllers';
 
 const router: Router = Router();
 
-router.post('/memo', InformationController.createDailyMemo);
+router.post('/', InformationController.createInformation);
 router.get('/days', InformationController.getDailyInformation);
-router.post('/emoji', InformationController.createEmoji);
-router.post('/days', InformationController.createDailyGoal);
 
 export default router;

--- a/src/routes/InformationRouter.ts
+++ b/src/routes/InformationRouter.ts
@@ -3,7 +3,7 @@ import { InformationController } from '../controllers';
 
 const router: Router = Router();
 
-router.post('/days', InformationController.createDailyMemo);
+router.post('/memo', InformationController.createDailyMemo);
 router.get('/days', InformationController.getDailyInformation);
 router.post('/emoji', InformationController.createEmoji);
 

--- a/src/routes/InformationRouter.ts
+++ b/src/routes/InformationRouter.ts
@@ -6,5 +6,6 @@ const router: Router = Router();
 router.post('/memo', InformationController.createDailyMemo);
 router.get('/days', InformationController.getDailyInformation);
 router.post('/emoji', InformationController.createEmoji);
+router.post('/days', InformationController.createDailyGoal);
 
 export default router;

--- a/src/services/InformationService.ts
+++ b/src/services/InformationService.ts
@@ -111,4 +111,37 @@ const createEmoji = async (
     throw error;
   }
 };
-export default { createDailyMemo, getDailyInformation, createEmoji };
+
+const createDailyGoal = async (
+  informationCreateDto: InformationCreateDto
+): Promise<void> => {
+  try {
+    // 특정 날짜, 유저, 타입과 일치하는 information이 존재하는지 탐색
+    const existingDailyGoals = await Information.find({
+      userId: informationCreateDto.userId,
+      date: informationCreateDto.date,
+      type: informationCreateDto.type,
+    });
+    if (existingDailyGoals.length === 0) {
+      // 존재하지 않는 경우, 새로운 information 객체 생성
+      const newDailyGoal = new Information(informationCreateDto);
+      await newDailyGoal.save();
+    } else {
+      // 존재하는 경우, 기존의 information 객체에 정보 업데이트
+      await Information.findByIdAndUpdate(
+        existingDailyGoals[0]._id,
+        informationCreateDto
+      );
+    }
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
+export default {
+  createDailyMemo,
+  getDailyInformation,
+  createEmoji,
+  createDailyGoal,
+};

--- a/src/services/InformationService.ts
+++ b/src/services/InformationService.ts
@@ -1,34 +1,26 @@
-import mongoose from 'mongoose';
 import { InformationCreateDto } from '../interfaces/information/InformationCreateDto';
 import { InformationResponseDto } from '../interfaces/information/InformationResponseDto';
 import Information from '../models/Information';
 
-const createDailyMemo = async (
+const createInformation = async (
   informationCreateDto: InformationCreateDto
 ): Promise<void> => {
   try {
-    const userId = '62cd6eb82b6b4e92c7fc08f1'; // 임시 구현
-    informationCreateDto.userId = new mongoose.Types.ObjectId(userId); // 명시적으로 결정
-    informationCreateDto.type = 'memo';
-    const isMemo = await Information.find({
+    // 특정 날짜, 유저, 타입과 일치하는 information이 존재하는지 탐색
+    const existingInformation = await Information.find({
+      userId: informationCreateDto.userId,
       date: informationCreateDto.date,
-      type: 'memo',
+      type: informationCreateDto.type,
     });
-    if (isMemo.length === 0) {
-      const dailyNote = new Information(informationCreateDto);
-      await dailyNote.save();
+    if (existingInformation.length === 0) {
+      // 존재하지 않는 경우, 새로운 information 객체 생성
+      const newDailyGoal = new Information(informationCreateDto);
+      await newDailyGoal.save();
     } else {
-      await Information.findOneAndUpdate(
-        {
-          $and: [
-            { userId: informationCreateDto.userId },
-            { date: informationCreateDto.date },
-          ],
-        },
-        {
-          value: informationCreateDto.value,
-        },
-        { new: true }
+      // 존재하는 경우, 기존의 information 객체에 정보 업데이트
+      await Information.findByIdAndUpdate(
+        existingInformation[0]._id,
+        informationCreateDto
       );
     }
   } catch (error) {
@@ -77,71 +69,7 @@ const getDailyInformation = async (
   }
 };
 
-const createEmoji = async (
-  informationCreateDto: InformationCreateDto
-): Promise<void> => {
-  try {
-    const userId = '62cd6eb82b6b4e92c7fc08f1'; // 임시 구현
-    informationCreateDto.userId = new mongoose.Types.ObjectId(userId); // 명시적으로 결정
-    informationCreateDto.type = 'emoji';
-
-    const isEmoji = await Information.find({
-      date: informationCreateDto.date,
-      type: 'emoji',
-    });
-    if (isEmoji.length === 0) {
-      const newEmoji = new Information(informationCreateDto);
-      await newEmoji.save();
-    } else {
-      await Information.findOneAndUpdate(
-        {
-          $and: [
-            { userId: informationCreateDto.userId },
-            { date: informationCreateDto.date },
-          ],
-        },
-        {
-          value: informationCreateDto.value,
-        },
-        { new: true }
-      );
-    }
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
-};
-
-const createDailyGoal = async (
-  informationCreateDto: InformationCreateDto
-): Promise<void> => {
-  try {
-    // 특정 날짜, 유저, 타입과 일치하는 information이 존재하는지 탐색
-    const existingDailyGoals = await Information.find({
-      userId: informationCreateDto.userId,
-      date: informationCreateDto.date,
-      type: informationCreateDto.type,
-    });
-    if (existingDailyGoals.length === 0) {
-      // 존재하지 않는 경우, 새로운 information 객체 생성
-      const newDailyGoal = new Information(informationCreateDto);
-      await newDailyGoal.save();
-    } else {
-      // 존재하는 경우, 기존의 information 객체에 정보 업데이트
-      await Information.findByIdAndUpdate(
-        existingDailyGoals[0]._id,
-        informationCreateDto
-      );
-    }
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
-};
-
 export default {
-  createDailyMemo,
+  createInformation,
   getDailyInformation,
-  createEmoji,
-  createDailyGoal,
 };


### PR DESCRIPTION
## Solved Issue
close #55 

<br>

## Motivation
- 현재 정보 작성의 경우, 일간 메모, 이모지, 일간 목표, 주간 목표, 월간 목표 작성 API로 모두 분리되어 있었음
- 하지만, 같은 콜렉션에 같은 형식으로 정보를 작성하고, 이들을 type으로 구별할 수 있음
- 따라서 type만 제외하고 완전히 같은 역할을 수행하는 함수와 API들을 통일하는 것이 올바른 구현이라고 생각함

<br>

## Key Changes
- responseMessage 통일
- Router - Controller 연결 통일
- Controller 구현
- Service 구현

<br>

## To Reviewers
- 처음 생각할 때부터 이걸 염두에 두고 내가 type을 쓰자고 한거였는데 왜 비효율적으로 하고있던건지 모르겠네 ㅎㅎ...
- 이렇게 하면 클라에서 붙일 때 type만 다르게 쓰고 똑같은 API 붙이면 되니까 그쪽도 훨씬 간단할듯!