### PR TITLE
[FEAT] 계획블록 수정 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@types/cors": "^2.8.12",
+    "@types/lodash": "^4.14.182",
     "axios": "^0.27.2",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
@@ -29,6 +30,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "express": "^4.17.3",
     "express-validator": "^6.14.0",
+    "lodash": "^4.17.21",
     "mongoose": "^6.4.4",
     "prettier": "^2.7.1"
   }

--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -7,6 +7,7 @@ import ScheduleService from '../services/ScheduleService';
 import mongoose from 'mongoose';
 import { ScheduleUpdateDto } from '../interfaces/schedule/ScheduleUpdateDto';
 import { TimeDto } from '../interfaces/schedule/TimeDto';
+import { SubScheduleIdTitleListDto } from '../interfaces/schedule/SubScheduleIdTitleListDto';
 
 /**
  * @route POST /schedule
@@ -646,6 +647,42 @@ const getCalendar = async (req: Request, res: Response) => {
   }
 };
 
+/**
+ * @route PATCH /schedule
+ * @desc Update Schedule
+ * @access Public
+ */
+const updateSchedule = async (req: Request, res: Response) => {
+  const { scheduleId, title, categoryColorCode, subSchedules } = req.body;
+  const scheduleUpdateDto: ScheduleUpdateDto = {
+    title: title,
+    categoryColorCode: categoryColorCode,
+  };
+  const subScheduleIdTitleListDto: SubScheduleIdTitleListDto = {
+    subSchedules: subSchedules,
+  };
+  try {
+    await ScheduleService.updateSchedule(
+      scheduleId,
+      scheduleUpdateDto,
+      subScheduleIdTitleListDto
+    );
+    res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.UPDATE_SCHEDULE_SUCCESS));
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(
+        util.fail(
+          statusCode.INTERNAL_SERVER_ERROR,
+          message.INTERNAL_SERVER_ERROR
+        )
+      );
+  }
+};
+
 export default {
   createSchedule,
   createTime,
@@ -664,4 +701,5 @@ export default {
   updateScheduleOrder,
   updateScheduleCategory,
   getCalendar,
+  updateSchedule,
 };

--- a/src/interfaces/schedule/SubScheduleIdTitleListDto.ts
+++ b/src/interfaces/schedule/SubScheduleIdTitleListDto.ts
@@ -1,0 +1,8 @@
+interface scheduleIdTitle {
+  scheduleId: string;
+  title: string;
+}
+
+export interface SubScheduleIdTitleListDto {
+  subSchedules: scheduleIdTitle[];
+}

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -27,6 +27,7 @@ const message = {
   UPDATE_SCHEDULE_ORDER_SUCCESS: '계획블록 순서 변경 성공',
   UPDATE_SCHEDULE_CATEGORY_SUCCESS: '계획블록 카테고리 변경 성공',
   GET_CALENDAR_WITH_SCHEDULES_SUCCESS: '날짜별 일정 존재 여부 조회 성공',
+  UPDATE_SCHEDULE_SUCCESS: '계획블록 수정 성공',
 };
 
 export default message;

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -20,5 +20,6 @@ router.post('/routine-day', ScheduleController.routineDay);
 router.patch('/order', ScheduleController.updateScheduleOrder);
 router.patch('/category', ScheduleController.updateScheduleCategory);
 router.get('/calendar', ScheduleController.getCalendar);
+router.patch('/', ScheduleController.updateSchedule);
 
 export default router;

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -7,6 +7,8 @@ import { ScheduleUpdateDto } from '../interfaces/schedule/ScheduleUpdateDto';
 import { ScheduleInfo } from '../interfaces/schedule/ScheduleInfo';
 import { calculateOrderIndex } from '../modules/calculateOrderIndex';
 import { TimeDto } from '../interfaces/schedule/TimeDto';
+import { SubScheduleIdTitleListDto } from '../interfaces/schedule/SubScheduleIdTitleListDto';
+import _ from 'lodash';
 
 const createSchedule = async (
   scheduleCreateDto: ScheduleCreateDto
@@ -603,6 +605,96 @@ const getCalendar = async (month: string): Promise<number[]> => {
   }
 };
 
+const updateSchedule = async (
+  scheduleId: string,
+  scheduleUpdateDto: ScheduleUpdateDto,
+  newSubSchedules: SubScheduleIdTitleListDto
+) => {
+  try {
+    // 상위 계획블록의 제목, 카테고리 색상 먼저 덮어 쓰고, 기존의 하위 계획 탐색
+    const existingSchedule = await Schedule.findByIdAndUpdate(
+      scheduleId,
+      scheduleUpdateDto
+    ).populate({
+      path: 'subSchedules',
+      model: 'Schedule',
+    });
+
+    if (!existingSchedule) {
+      // scheduleId에 해당하는 원본 계획블록이 없는 경우, null을 return
+      return existingSchedule;
+    }
+
+    // 기존 하위 계획 블록들로 새로운 하위 계획 블록의 orderIndex 계산
+    let existingSubSchedules = await Promise.all(
+      existingSchedule.subSchedules.map((existingSubSchedule: any) => {
+        const result = {
+          date: '',
+          title: existingSubSchedule.title,
+          categoryColorCode: existingSubSchedule.categoryColorCode,
+          userId: existingSubSchedule.userId,
+          orderIndex: existingSubSchedule.orderIndex,
+          isRoutine: true,
+        };
+        return result;
+      })
+    );
+    existingSubSchedules = existingSubSchedules.sort(
+      (a, b) => a.orderIndex - b.orderIndex
+    );
+    let newSubScheduleOrderIndex = calculateOrderIndex(
+      existingSubSchedules as ScheduleInfo[]
+    );
+
+    // promise.all로 하위 계획 생성 / 업데이트 처리
+    let newSubScheduleIds = await Promise.all(
+      newSubSchedules.subSchedules.map(async (newSubSchedule: any) => {
+        if (!newSubSchedule.scheduleId) {
+          // id가 존재하지 않는 경우 : 새로 생성할 하위 계획 : 새로운 계획 생성 및 id 배열에 push
+          const scheduleCreateDto: ScheduleCreateDto = {
+            date: existingSchedule.date,
+            title: newSubSchedule.title,
+            categoryColorCode: scheduleUpdateDto.categoryColorCode!,
+            userId: existingSchedule.userId,
+            orderIndex: newSubScheduleOrderIndex,
+          };
+          newSubScheduleOrderIndex += 1024;
+          const schedule = new Schedule(scheduleCreateDto);
+          await schedule.save();
+          return schedule._id;
+        } else {
+          // id가 존재하는 경우 : 이미 존재하는 하위 계획 : 기존 하위 계획 title, categoryColorCode 업데이트
+          const subScheduleUpdateDto: ScheduleUpdateDto = {
+            title: newSubSchedule.title,
+            categoryColorCode: scheduleUpdateDto.categoryColorCode,
+          };
+          await Schedule.findByIdAndUpdate(
+            newSubSchedule.scheduleId,
+            subScheduleUpdateDto
+          );
+        }
+      })
+    );
+    newSubScheduleIds = _.compact(newSubScheduleIds); // id 배열에서 undefined 삭제
+
+    // 상위 계획블록의 subSchedules 배열에 새로 만든 하위 계획의 id 삽입
+    await Schedule.findByIdAndUpdate(
+      {
+        _id: scheduleId,
+      },
+      {
+        $push: { subSchedules: { $each: newSubScheduleIds } },
+      },
+      {
+        new: true,
+      }
+    );
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
 export default {
   createSchedule,
   deleteSchedule,
@@ -621,4 +713,5 @@ export default {
   updateScheduleOrder,
   updateScheduleCategory,
   getCalendar,
+  updateSchedule,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,6 +140,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/lodash@^4.14.182":
+  version "4.14.182"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
+  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
+
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"


### PR DESCRIPTION
## Solved Issue
close #68 

<br>

## Motivation
- 모달 창에서 완료 버튼을 눌렀을 시, 계획블록을 수정하는 API를 구현합니다.
- 상위 계획 제목, 카테고리 수정
- 하위 계획 정보 전체 비교해 서버 측에서 분기
- 이미 존재하는 하위 계획 : 업데이트
- 새로 생성할 하위 계획 : 새로 생성 및 상위 계획의 subSchedules 배열에 id 삽입

<br>

## Key Changes
- lodash 패키지 설치 (배열 관리할 때 유용한 패키지)
- responseMessage 추가
- SubScheduleIdTitleListDto 구현 (계속 활용할 req.body로 받은 데이터의 타입 지정 위함)
- Router - Controller 연결
- Controller 구현
- Service 구현

<br>

## To Reviewers
- 다른 부분은 이해하기 쉬운데, 하위계획 처리하는 부분이 굉장히 머리가 아팠습니다...!
- 하위 계획이 많을 경우 속도가 느려질 수 있다는 점을 고려해 promise.all을 이용, 하위 계획 업데이트 / 생성 모두 병렬적으로 처리했습니다.
