### PR TITLE
[FEAT] 계획블록 요일 이동 API

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -646,6 +646,45 @@ const getCalendar = async (req: Request, res: Response) => {
   }
 };
 
+/**
+ * @route PATCH /schedule/days
+ * @desc Move Schedule to Other Days
+ * @access Public
+ */
+const moveDays = async (req: Request, res: Response) => {
+  const { scheduleId, date } = req.body;
+  if (!scheduleId || !date) {
+    return res
+      .status(statusCode.BAD_REQUEST)
+      .send(util.fail(statusCode.BAD_REQUEST, message.NULL_VALUE));
+  }
+
+  try {
+    const moveScheduleToOtherDays = await ScheduleService.moveDays(
+      scheduleId,
+      date
+    );
+    if (!moveScheduleToOtherDays) {
+      // scheduleId가 잘못된 경우, 404 return
+      return res
+        .status(statusCode.NOT_FOUND)
+        .send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND));
+    }
+    res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.MOVE_DAYS_SUCCESS));
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(
+        util.fail(
+          statusCode.INTERNAL_SERVER_ERROR,
+          message.INTERNAL_SERVER_ERROR
+        )
+      );
+  }
+};
 export default {
   createSchedule,
   createTime,
@@ -664,4 +703,5 @@ export default {
   updateScheduleOrder,
   updateScheduleCategory,
   getCalendar,
+  moveDays,
 };

--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -651,18 +651,21 @@ const getCalendar = async (req: Request, res: Response) => {
  * @desc Move Schedule to Other Days
  * @access Public
  */
-const moveDays = async (req: Request, res: Response) => {
+const updateScheduleDate = async (req: Request, res: Response) => {
   const { scheduleId, date } = req.body;
   if (!scheduleId || !date) {
     return res
       .status(statusCode.BAD_REQUEST)
       .send(util.fail(statusCode.BAD_REQUEST, message.NULL_VALUE));
   }
+  const scheduleUpdateDto: ScheduleUpdateDto = {
+    date: date,
+  };
 
   try {
-    const moveScheduleToOtherDays = await ScheduleService.moveDays(
+    const moveScheduleToOtherDays = await ScheduleService.updateScheduleDate(
       scheduleId,
-      date
+      scheduleUpdateDto
     );
     if (!moveScheduleToOtherDays) {
       // scheduleId가 잘못된 경우, 404 return
@@ -672,7 +675,7 @@ const moveDays = async (req: Request, res: Response) => {
     }
     res
       .status(statusCode.OK)
-      .send(util.success(statusCode.OK, message.MOVE_DAYS_SUCCESS));
+      .send(util.success(statusCode.OK, message.UPDATE_SCHEDULE_DATE_SUCCESS));
   } catch (error) {
     console.log(error);
     return res
@@ -703,5 +706,5 @@ export default {
   updateScheduleOrder,
   updateScheduleCategory,
   getCalendar,
-  moveDays,
+  updateScheduleDate,
 };

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -27,7 +27,7 @@ const message = {
   UPDATE_SCHEDULE_ORDER_SUCCESS: '계획블록 순서 변경 성공',
   UPDATE_SCHEDULE_CATEGORY_SUCCESS: '계획블록 카테고리 변경 성공',
   GET_CALENDAR_WITH_SCHEDULES_SUCCESS: '날짜별 일정 존재 여부 조회 성공',
-  MOVE_DAYS_SUCCESS: '계획블록 요일 이동 성공',
+  UPDATE_SCHEDULE_DATE_SUCCESS: '계획블록 요일 이동 성공',
 };
 
 export default message;

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -27,6 +27,7 @@ const message = {
   UPDATE_SCHEDULE_ORDER_SUCCESS: '계획블록 순서 변경 성공',
   UPDATE_SCHEDULE_CATEGORY_SUCCESS: '계획블록 카테고리 변경 성공',
   GET_CALENDAR_WITH_SCHEDULES_SUCCESS: '날짜별 일정 존재 여부 조회 성공',
+  MOVE_DAYS_SUCCESS: '계획블록 요일 이동 성공',
 };
 
 export default message;

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -20,5 +20,6 @@ router.post('/routine-day', ScheduleController.routineDay);
 router.patch('/order', ScheduleController.updateScheduleOrder);
 router.patch('/category', ScheduleController.updateScheduleCategory);
 router.get('/calendar', ScheduleController.getCalendar);
+router.patch('/days', ScheduleController.moveDays);
 
 export default router;

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -20,6 +20,6 @@ router.post('/routine-day', ScheduleController.routineDay);
 router.patch('/order', ScheduleController.updateScheduleOrder);
 router.patch('/category', ScheduleController.updateScheduleCategory);
 router.get('/calendar', ScheduleController.getCalendar);
-router.patch('/days', ScheduleController.moveDays);
+router.patch('/days', ScheduleController.updateScheduleDate);
 
 export default router;

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -603,6 +603,36 @@ const getCalendar = async (month: string): Promise<number[]> => {
   }
 };
 
+const moveDays = async (
+  scheduleId: string,
+  date: string
+): Promise<ScheduleInfo | null> => {
+  try {
+    // date로 요일 계획블록 조회
+    const moveSchedule = await Schedule.find({
+      date: date,
+    }).sort({ orderIndex: 1 });
+
+    // 새로운 orderIndex 생성
+    const newIndex = calculateOrderIndex(moveSchedule);
+
+    // date와 orderIndex 수정
+    const moveScheduleToOtherDays = await Schedule.findByIdAndUpdate(
+      {
+        _id: scheduleId,
+      },
+      {
+        $set: { date: date, orderIndex: newIndex },
+      },
+      { new: true }
+    );
+
+    return moveScheduleToOtherDays;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
 export default {
   createSchedule,
   deleteSchedule,
@@ -621,4 +651,5 @@ export default {
   updateScheduleOrder,
   updateScheduleCategory,
   getCalendar,
+  moveDays,
 };

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -603,14 +603,14 @@ const getCalendar = async (month: string): Promise<number[]> => {
   }
 };
 
-const moveDays = async (
+const updateScheduleDate = async (
   scheduleId: string,
-  date: string
+  scheduleUpdateDto: ScheduleUpdateDto
 ): Promise<ScheduleInfo | null> => {
   try {
     // date로 요일 계획블록 조회
     const moveSchedule = await Schedule.find({
-      date: date,
+      date: scheduleUpdateDto.date,
     }).sort({ orderIndex: 1 });
 
     // 새로운 orderIndex 생성
@@ -622,7 +622,7 @@ const moveDays = async (
         _id: scheduleId,
       },
       {
-        $set: { date: date, orderIndex: newIndex },
+        $set: { date: scheduleUpdateDto.date, orderIndex: newIndex },
       },
       { new: true }
     );
@@ -651,5 +651,5 @@ export default {
   updateScheduleOrder,
   updateScheduleCategory,
   getCalendar,
-  moveDays,
+  updateScheduleDate,
 };


### PR DESCRIPTION
## Solved Issue
close #72 

<br>

## Motivation
- 주간 계획표에서 계획블록 요일을 이동합니다.

<br>

## Key Changes
- responseMessage 추가
- Schedule Service moveDays 구현
- Schedule Controller moveDays 구현
- Router-Controller 연결

<br>

## To Reviewers
- 클라분들에게 조금이나마 빠르게 전해드리고자 오늘 요일 이동까지만 구현하고 마무리하려고 합니다!
- 올려놓으신 PR은 내일 꼼꼼히 읽어보도록 하겠습니다!
- 로직 확인해주시고 피드백 부탁드립니당:)
