### PR TITLE
[FEAT] 주간 계획 계획블록 리스트 조회 API

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -648,7 +648,8 @@ const getCalendar = async (req: Request, res: Response) => {
   }
 };
 
-* @route PATCH /schedule
+/**
+ * @route PATCH /schedule
  * @desc Update Schedule
  * @access Public
  */
@@ -713,7 +714,7 @@ const updateScheduleDate = async (req: Request, res: Response) => {
     res
       .status(statusCode.OK)
       .send(util.success(statusCode.OK, message.UPDATE_SCHEDULE_DATE_SUCCESS));
- } catch (error) {
+  } catch (error) {
     console.log(error);
     return res
       .status(statusCode.INTERNAL_SERVER_ERROR)

--- a/src/modules/calculateDaysOfWeek.ts
+++ b/src/modules/calculateDaysOfWeek.ts
@@ -1,0 +1,37 @@
+export const calculateDaysOfWeek = (
+  startDate: string,
+  endDate: string
+): string[] => {
+  let daysOfWeek: string[] = [];
+  if (startDate.substring(0, 7) === endDate.substring(0, 7)) {
+    // 한 주 내에서 월이 바뀌지 않는 경우 (같은 달인 경우)
+    const yearAndMonth: string = startDate.substring(0, 8);
+    const day = parseInt(startDate.substring(8, 10));
+    for (let counter = 0; counter < 7; counter++) {
+      daysOfWeek.push(`${yearAndMonth}${('00' + (day + counter)).slice(-2)}`);
+    }
+  } else {
+    // 한 주 내에서 월이 바뀌는 경우
+    const startYearAndMonth: string = startDate.substring(0, 8);
+    const startDay = parseInt(startDate.substring(8, 10));
+    const endYearAndMonth: string = endDate.substring(0, 8);
+    let endDay = parseInt(endDate.substring(8, 10));
+    let counter = 7;
+    while (endDay > 0) {
+      daysOfWeek.push(`${endYearAndMonth}${('00' + endDay).slice(-2)}`);
+      endDay--;
+      counter--;
+    }
+    for (
+      let oldMonthCounter = 0;
+      oldMonthCounter < counter;
+      oldMonthCounter++
+    ) {
+      daysOfWeek.push(
+        `${startYearAndMonth}${('00' + (startDay + oldMonthCounter)).slice(-2)}`
+      );
+    }
+    daysOfWeek.sort();
+  }
+  return daysOfWeek;
+};

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -28,6 +28,7 @@ const message = {
   UPDATE_SCHEDULE_CATEGORY_SUCCESS: '계획블록 카테고리 변경 성공',
   GET_CALENDAR_WITH_SCHEDULES_SUCCESS: '날짜별 일정 존재 여부 조회 성공',
   UPDATE_SCHEDULE_SUCCESS: '계획블록 수정 성공',
+  GET_WEEKLY_SCHEDULES_SUCCESS: '주간 계획블록 리스트 조회 성공',
 };
 
 export default message;

--- a/src/routes/ScheduleRouter.ts
+++ b/src/routes/ScheduleRouter.ts
@@ -21,5 +21,6 @@ router.patch('/order', ScheduleController.updateScheduleOrder);
 router.patch('/category', ScheduleController.updateScheduleCategory);
 router.get('/calendar', ScheduleController.getCalendar);
 router.patch('/', ScheduleController.updateSchedule);
+router.get('/weeks', ScheduleController.getWeeklySchedules);
 
 export default router;

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -698,7 +698,7 @@ const updateSchedule = async (
         _id: scheduleId,
       },
       {
-        $set: { date: scheduleUpdateDto.date, orderIndex: newIndex },
+        $push: { subSchedules: { $each: newSubScheduleIds } },
       },
       { new: true }
     );
@@ -723,13 +723,17 @@ const updateScheduleDate = async (
 
     // date와 orderIndex 수정
     const moveScheduleToOtherDays = await Schedule.findByIdAndUpdate(
-        $push: { subSchedules: { $each: newSubScheduleIds } },
+      {
+        _id: scheduleId,
+      },
+      {
+        $set: { date: scheduleUpdateDto.date, orderIndex: newIndex },
       },
       {
         new: true,
       }
     );
-   
+
     return moveScheduleToOtherDays;
   } catch (error) {
     console.log(error);

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -9,6 +9,7 @@ import { calculateOrderIndex } from '../modules/calculateOrderIndex';
 import { TimeDto } from '../interfaces/schedule/TimeDto';
 import { SubScheduleIdTitleListDto } from '../interfaces/schedule/SubScheduleIdTitleListDto';
 import _ from 'lodash';
+import { calculateDaysOfWeek } from '../modules/calculateDaysOfWeek';
 
 const createSchedule = async (
   scheduleCreateDto: ScheduleCreateDto
@@ -709,6 +710,29 @@ const updateSchedule = async (
   }
 };
 
+const getWeeklySchedules = async (
+  userId: string,
+  startDate: string,
+  endDate: string
+): Promise<ScheduleListGetDto[]> => {
+  try {
+    const daysOfWeek = calculateDaysOfWeek(startDate, endDate);
+    const schedulesOfWeek = await Promise.all(
+      daysOfWeek.map(async (day: string) => {
+        const schedulesOfDay = await Schedule.find({
+          date: day,
+          userId: userId,
+        }).sort({ orderIndex: 1 });
+        return { schedules: schedulesOfDay };
+      })
+    );
+    return schedulesOfWeek;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
 export default {
   createSchedule,
   deleteSchedule,
@@ -728,4 +752,5 @@ export default {
   updateScheduleCategory,
   getCalendar,
   updateSchedule,
+  getWeeklySchedules,
 };


### PR DESCRIPTION
## Solved Issue
close #76 

<br>

## Motivation
- 주간 계획 뷰에서 1주일동안의 계획블록 리스트를 조회하는 API를 구현합니다.

<br>

## Key Changes
- responseMessage 추가
- Router - Controller 연결
- Controller 구현
- calculateDaysOfWeek 모듈화
- Service 구현

<br>

## To Reviewers
- calculateDaysOfWeek를 통해 주간의 첫째 날과 마지막 날만으로 한 주의 전체 날짜를 구할 수 있도록 구현했습니다.
- 중간에 월이 바뀌거나, 28, 30, 31 등 마지막 날이 일정하지 않는 경우를 고려했습니다.
- 주간 뷰 이모지 리스트 조회 시에도 활용하기 위해 모듈화했습니다.
