### PR TITLE
[HOTFIX] userId 타입 일괄적으로 string으로 변경

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -319,7 +319,7 @@ const completeSchedule = async (req: Request, res: Response) => {
  * @access Public
  */
 const getReschedules = async (req: Request, res: Response) => {
-  const userId = new mongoose.Types.ObjectId('62cd27ae39f42cfbf520009a');
+  const userId = '62cd27ae39f42cfbf520009a';
   try {
     const data = await ScheduleService.getReschedules(userId);
     return res
@@ -400,7 +400,7 @@ const createRoutine = async (req: Request, res: Response) => {
   }
 
   scheduleId = new mongoose.Types.ObjectId(scheduleId);
-  const userId = new mongoose.Types.ObjectId('62cd27ae39f42cfbf520009a');
+  const userId = '62cd27ae39f42cfbf520009a';
 
   try {
     const newRoutine = await ScheduleService.createRoutine(userId, scheduleId);
@@ -434,7 +434,7 @@ const createRoutine = async (req: Request, res: Response) => {
  * @access Public
  */
 const getRoutines = async (req: Request, res: Response) => {
-  const userId = new mongoose.Types.ObjectId('62cd27ae39f42cfbf520009a');
+  const userId = '62cd27ae39f42cfbf520009a';
   try {
     const routines = await ScheduleService.getRoutines(userId);
     res
@@ -515,7 +515,7 @@ const routineDay = async (req: Request, res: Response) => {
   }
 
   scheduleId = new mongoose.Types.ObjectId(scheduleId);
-  const userId = new mongoose.Types.ObjectId('62cd27ae39f42cfbf520009a');
+  const userId = '62cd27ae39f42cfbf520009a';
   try {
     const moveRoutineToSchedule = await ScheduleService.routineDay(
       userId,

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -293,7 +293,7 @@ const getSubSchedules = async (
 };
 
 const getReschedules = async (
-  userId: mongoose.Types.ObjectId
+  userId: string
 ): Promise<RescheduleListGetDto> => {
   try {
     const delaySchedules = await Schedule.find({
@@ -331,7 +331,7 @@ const updateScheduleTitle = async (
 };
 
 const createRoutine = async (
-  userId: mongoose.Types.ObjectId,
+  userId: string,
   scheduleId: mongoose.Types.ObjectId
 ): Promise<ScheduleInfo | null> => {
   try {
@@ -357,7 +357,7 @@ const createRoutine = async (
       date: '',
       title: originalSchedule.title,
       categoryColorCode: originalSchedule.categoryColorCode,
-      userId: originalSchedule.userId,
+      userId: originalSchedule.userId.toString(),
       orderIndex: newIndex,
       isRoutine: true,
       subSchedules: [],
@@ -395,9 +395,7 @@ const createRoutine = async (
   }
 };
 
-const getRoutines = async (
-  userId: mongoose.Types.ObjectId
-): Promise<ScheduleListGetDto> => {
+const getRoutines = async (userId: string): Promise<ScheduleListGetDto> => {
   try {
     const routines = await Schedule.find({
       userId: userId,
@@ -443,7 +441,7 @@ const rescheduleDay = async (
 };
 
 const routineDay = async (
-  userId: mongoose.Types.ObjectId,
+  userId: string,
   scheduleId: mongoose.Types.ObjectId,
   date: string
 ): Promise<ScheduleInfo | null> => {
@@ -469,7 +467,7 @@ const routineDay = async (
       date: date,
       title: moveRoutineToSchedule.title,
       categoryColorCode: moveRoutineToSchedule.categoryColorCode,
-      userId: moveRoutineToSchedule.userId,
+      userId: moveRoutineToSchedule.userId.toString(),
       orderIndex: newIndex,
       isRoutine: false,
       subSchedules: [],
@@ -662,7 +660,7 @@ const updateSchedule = async (
             date: existingSchedule.date,
             title: newSubSchedule.title,
             categoryColorCode: scheduleUpdateDto.categoryColorCode!,
-            userId: existingSchedule.userId,
+            userId: existingSchedule.userId.toString(),
             orderIndex: newSubScheduleOrderIndex,
           };
           newSubScheduleOrderIndex += 1024;


### PR DESCRIPTION
## Solved Issue
close #91 

<br>

## Motivation
- ScheduleCreateDto의 userId가 mongoose.Types.ObjectId로 변경되어 발생할 수 있는 문제를 방지하기 위해 userId를 일괄적으로 string으로 수정합니다.

<br>

## Key Changes
- ScheduleController 점검 및 userId 부분 일괄 수정
- ScheduleService 점검 및 userId 부분 일괄 수정

<br>

## To Reviewers
- 너무 많아서 보기 힘들...지도
- 부모 계획블록에서 받아 온 id는 objectId 타입이므로, 이를 createDto에 넣을때는 .toString() 메서드를 이용해서 string으로 변경해줬습니다
