### PR TITLE
[IMPROVE] 계획블록 미루기 API 수정 및 보완

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -156,10 +156,11 @@ const deleteTime = async (req: Request, res: Response) => {
  * @access Public
  */
 const dayReschedule = async (req: Request, res: Response) => {
-  let { scheduleId } = req.body;
-  scheduleId = new mongoose.Types.ObjectId(scheduleId);
+  let { scheduleId } = req.query;
   try {
-    const delaySchedule = await ScheduleService.dayReschedule(scheduleId);
+    const delaySchedule = await ScheduleService.dayReschedule(
+      scheduleId as string
+    );
 
     if (!delaySchedule) {
       // scheduleId가 잘못된 경우, 404 return
@@ -172,6 +173,13 @@ const dayReschedule = async (req: Request, res: Response) => {
       .send(util.success(statusCode.OK, message.DELAY_SCHEDULE_SUCCESS));
   } catch (error) {
     console.log(error);
+    const errorMessage: string = slackMessage(
+      req.method.toUpperCase(),
+      req.originalUrl,
+      error,
+      req.body.user?.id
+    );
+    sendMessagesToSlack(errorMessage);
     return res
       .status(statusCode.INTERNAL_SERVER_ERROR)
       .send(

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -202,12 +202,12 @@ const dayReschedule = async (
 ): Promise<ScheduleInfo | null> => {
   try {
     // 계획블록의 isReschedule true로 전환, 시간 데이터 삭제
-    const delaySchedule = await Schedule.findOneAndUpdate(
+    const delaySchedule = await Schedule.findByIdAndUpdate(
       {
         _id: scheduleId,
       },
       {
-        $set: { isReschedule: true, timeSets: [] },
+        $set: { isReschedule: true, estimateTime: [], usedTime: [] },
       },
       { new: true }
     );

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -198,7 +198,7 @@ const deleteTime = async (
 };
 
 const dayReschedule = async (
-  scheduleId: mongoose.Types.ObjectId
+  scheduleId: string
 ): Promise<ScheduleInfo | null> => {
   try {
     // 계획블록의 isReschedule true로 전환, 시간 데이터 삭제

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -207,7 +207,7 @@ const dayReschedule = async (
         _id: scheduleId,
       },
       {
-        $set: { isReschedule: true, estimateTime: [], usedTime: [] },
+        $set: { isReschedule: true, estimatedTime: [], usedTime: [] },
       },
       { new: true }
     );

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -203,9 +203,7 @@ const dayReschedule = async (
   try {
     // 계획블록의 isReschedule true로 전환, 시간 데이터 삭제
     const delaySchedule = await Schedule.findByIdAndUpdate(
-      {
-        _id: scheduleId,
-      },
+      scheduleId,
       {
         $set: { isReschedule: true, estimatedTime: [], usedTime: [] },
       },


### PR DESCRIPTION
## Solved Issue
close #97 

<br>

## Motivation
- 일간계획표에서 계획블록을 미룹니다.

<br>

## Key Changes
- [x] Controller에 Slack Error Monitoring 코드 추가
- [x] request query, body 점검 (id처럼 자원 식별용이면 query) -> scheduleId 를 query로 받게 함
- [x] scheduleId도 type string으로 통일
- [x] 더 효율적으로 할 수 있을 것 같은 부분 있으면 알려주기 -> findByIdAndUpdate, timeSets를 estimatedTime, usedTime으로 변경
- [x] API 명세서 재확인 후 수정 ->URL query 추가

<br>

## To Reviewers
- 확인 부탁드립니다!
