### PR TITLE
[FIX] 하위 계획블록 생성 시 date값 삭제

### DIFF
--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -505,7 +505,7 @@ const getRoutines = async (req: Request, res: Response) => {
 };
 
 /**
- * @route PATCH /schedule/reschedule-day
+ * @route PATCH /schedule/reschedule-day?scheduleId=
  * @desc Move Reschedule back to Schedules
  * @access Public
  */

--- a/src/controllers/ScheduleController.ts
+++ b/src/controllers/ScheduleController.ts
@@ -732,7 +732,7 @@ const getCalendar = async (req: Request, res: Response) => {
 };
 
 /**
- * @route PATCH /schedule
+ * @route PATCH /schedule?scheduleId=
  * @desc Update Schedule
  * @access Public
  */

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -615,7 +615,7 @@ const updateSchedule = async (
   scheduleId: string,
   scheduleUpdateDto: ScheduleUpdateDto,
   newSubSchedules: SubScheduleIdTitleListDto
-): Promise<void | null> => {
+): Promise<ScheduleInfo | null> => {
   try {
     // 상위 계획블록의 제목, 카테고리 색상 먼저 덮어 쓰고, 기존의 하위 계획 탐색
     const existingSchedule = await Schedule.findByIdAndUpdate(
@@ -689,6 +689,7 @@ const updateSchedule = async (
     await Schedule.findByIdAndUpdate(scheduleId, {
       $push: { subSchedules: { $each: newSubScheduleIds } },
     });
+    return existingSchedule;
   } catch (error) {
     console.log(error);
     throw error;

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -411,7 +411,7 @@ const rescheduleDay = async (
       // 하위 계획블록도 동일하게 처리
       for (const moveBackSubSchedule of moveBackSchedule.subSchedules) {
         await Schedule.findByIdAndUpdate(moveBackSubSchedule._id, {
-          $set: { isReschedule: false, date: scheduleUpdateDto.date },
+          $set: { isReschedule: false, date: '' },
         });
       }
     }

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -658,7 +658,7 @@ const updateSchedule = async (
         if (!newSubSchedule.scheduleId) {
           // id가 존재하지 않는 경우 : 새로 생성할 하위 계획 : 새로운 계획 생성 및 id 배열에 push
           const scheduleCreateDto: ScheduleCreateDto = {
-            date: existingSchedule.date,
+            date: '',
             title: newSubSchedule.title,
             categoryColorCode: scheduleUpdateDto.categoryColorCode!,
             userId: existingSchedule.userId.toString(),

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -447,7 +447,7 @@ const routineDay = async (
 
     // 새로운 계획블록 생성
     const newSchedule: ScheduleCreateDto = {
-      date: scheduleUpdateDto.date!,
+      date: '',
       title: moveRoutineToSchedule.title,
       categoryColorCode: moveRoutineToSchedule.categoryColorCode,
       userId: moveRoutineToSchedule.userId.toString(),


### PR DESCRIPTION
## Solved Issue
close #128 

<br>

## Motivation
- 하위 계획블록들이 date값을 가지고 있어, 일간 / 주간 계획블록 조회 시 모두 표시되는 버그를 수정합니다.

<br>

## Key Changes
- 계획블록 수정 API에서 하위계획 생성 시, date 값 빈 string으로 지정
- 미룬 계획을 일간 계획으로 옮길 시, date 값 빈 string으로 지정
- 자주 사용하는 계획을 일간 계획으로 옮길 시, date 값 빈 string으로 지정
- updateschedule Controller 주석 route에 req.query 표시
- rescheduleDay Controller 주석 route에 req.query 표시
- updateSchedule 반환 타입 scheduleInfo | null로 변경

<br>

## To Reviewers
- 봐도 봐도 잘못된게 보이는 이... 현상은 무엇일까