### PR TITLE
[FIX] 월간 조회 API 수정

### DIFF
--- a/src/interfaces/information/DailyInformationResponseDto.ts
+++ b/src/interfaces/information/DailyInformationResponseDto.ts
@@ -1,5 +1,5 @@
 export interface DailyInformationResponseDto {
-  emoji: string | null;
-  dailyGoal: string | null;
-  memo: string | null;
+  emoji: string;
+  dailyGoal: string;
+  memo: string;
 }

--- a/src/interfaces/information/InformationResponseDto.ts
+++ b/src/interfaces/information/InformationResponseDto.ts
@@ -1,5 +1,5 @@
 export interface InformationResponseDto {
   date: string;
   type: string;
-  value: string | null;
+  value: string;
 }

--- a/src/interfaces/information/InformationResponseDto.ts
+++ b/src/interfaces/information/InformationResponseDto.ts
@@ -1,7 +1,5 @@
-import mongoose from 'mongoose';
-
 export interface InformationResponseDto {
   date: string;
   type: string;
-  value: string;
+  value: string | null;
 }

--- a/src/services/InformationService.ts
+++ b/src/services/InformationService.ts
@@ -47,9 +47,9 @@ const getDailyInformation = async (
     });
 
     let data: DailyInformationResponseDto = {
-      emoji: null,
-      dailyGoal: null,
-      memo: null,
+      emoji: '',
+      dailyGoal: '',
+      memo: '',
     };
 
     if (emoji) {

--- a/src/services/InformationService.ts
+++ b/src/services/InformationService.ts
@@ -90,7 +90,7 @@ const getMonthlyGoal = async (
     let data: InformationResponseDto = {
       date: date,
       type: 'monthlyGoal',
-      value: null,
+      value: '',
     };
 
     if (findMonthlyGoal) {

--- a/src/services/InformationService.ts
+++ b/src/services/InformationService.ts
@@ -72,26 +72,31 @@ const getMonthlyGoal = async (
   date: string,
   userId: mongoose.Types.ObjectId
 ): Promise<InformationResponseDto> => {
-  const dateRegex = date.substring(0, 7);
   try {
-    const findMonthlyGoal = await Information.find({
+    const findMonthlyGoal = await Information.findOne({
       $and: [
         {
           userId: userId,
         },
         {
-          date: { $regex: dateRegex },
+          date: date,
         },
         {
           type: 'monthlyGoal',
         },
       ],
     });
-    const data: InformationResponseDto = {
-      date: findMonthlyGoal[0].date,
-      type: findMonthlyGoal[0].type,
-      value: findMonthlyGoal[0].value,
+
+    let data: InformationResponseDto = {
+      date: date,
+      type: 'monthlyGoal',
+      value: null,
     };
+
+    if (findMonthlyGoal) {
+      data.value = findMonthlyGoal.value;
+    }
+
     return data;
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
## Solved Issue
close #140 

<br>

## Motivation
- 월간 목표 조회시 월간 목표 데이터가 없을 경우 500에러를 수정

<br>

## Key Changes
- 데이터가 없을 시 value가 null인 경우를 조회하도록 함

<br>

## To Reviewers
- 확인 부탁드려요! 혹시나 코드가 스파게티일수도 있으니 피드백도 부탁드립니당..!
- 어차피 그 달의 첫째날도 받기도 했어서 substring 로직은 삭제했어요~!