### PR TITLE
[FIX] 계획블록 시간 삭제 API 수정

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
-
-yarn run test

--- a/src/interfaces/schedule/TimeDto.ts
+++ b/src/interfaces/schedule/TimeDto.ts
@@ -1,4 +1,4 @@
 export interface TimeDto {
-  isUsed: boolean;
+  isUsed?: boolean;
   timeBlockNumbers: [number];
 }

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -159,28 +159,16 @@ const deleteTime = async (
     const deleteScheduleTime = await Schedule.findById(scheduleId);
     if (!deleteScheduleTime) {
       return null;
-    } else {
-      if (timeDto.isUsed === false) {
-        await Schedule.findByIdAndUpdate(
-          scheduleId,
-          {
-            $pull: { estimatedTime: { $in: timeDto.timeBlockNumbers } },
-          },
-          {
-            new: true,
-          }
-        );
-      } else {
-        await Schedule.findByIdAndUpdate(
-          scheduleId,
-          {
-            $pull: { usedTime: { $in: timeDto.timeBlockNumbers } },
-          },
-          {
-            new: true,
-          }
-        );
-      }
+    } else{
+      await Schedule.findByIdAndUpdate(
+        scheduleId,
+        {
+          $pull: { estimatedTime: { $in: timeDto.timeBlockNumbers } , usedTime: { $in: timeDto.timeBlockNumbers } },
+        },
+        {
+          new: true,
+        }
+      );
     }
     return deleteScheduleTime;
   } catch (error) {


### PR DESCRIPTION
## Solved Issue
close #143 

<br>

## Motivation
- 계획블록 시간 삭제 시 겹쳐진 시간의 경우 실제 활용 시간과 예상 계획 시간 둘 다 삭제하지 못함

<br>

## Key Changes
- isUsed 선택적 프로퍼티 적용
- deleteTime 로직 수정

<br>

## To Reviewers
- 확인 후 피드백 부탁드립니다!
