### PR TITLE
[FIX] 미룰 계획블록, 자주 사용하는 계획블록 API 수정

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
+
+

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -365,6 +365,7 @@ const getRoutines = async (userId: string): Promise<ScheduleListGetDto> => {
   try {
     const routines = await Schedule.find({
       userId: userId,
+      subSchedules: { $exists: true, $not: { $size: 0 }},
       isRoutine: true,
     }).sort({ orderIndex: 1 });
 

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -267,6 +267,7 @@ const getReschedules = async (
   try {
     const delaySchedules = await Schedule.find({
       userId: userId,
+      subSchedules: { $exists: true, $not: { $size: 0 }},
       isReschedule: true,
     }).sort({ orderIndex: 1 });
 


### PR DESCRIPTION
## Solved Issue
close #152 

<br>

## Motivation
- 미룰 계획, 자주 사용하는 계획 시 하위 계획블록까지 노출

<br>

## Key Changes
- db 접근 시 $exists를 추가하여 상위계획만 노출시키도록 함

<br>

## To Reviewers
- 확인 부탁드리고 이상 없으면 머지해주세요!
