### PR TITLE
[FIX] 하위 계획블록 생성 시, 임시로 date를 하위 계획블록 flag로 사용하도록 수정

### DIFF
--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -368,7 +368,7 @@ const getRoutines = async (userId: string): Promise<ScheduleListGetDto> => {
   try {
     const routines = await Schedule.find({
       userId: userId,
-      subSchedules: { $exists: true, $not: { $size: 0 } },
+      date: { $ne: 'subSchedule' },
       isRoutine: true,
     }).sort({ orderIndex: 1 });
 

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -90,13 +90,13 @@ const completeSchedule = async (
     if (!checkCompleteSchedule) {
       return null;
     } else {
-        await Schedule.findByIdAndUpdate(
-          scheduleId,
-          {
-            $set: { isCompleted: isCompletedToBool, usedTime: [] },
-          },
-          { new: true }
-        )
+      await Schedule.findByIdAndUpdate(
+        scheduleId,
+        {
+          $set: { isCompleted: isCompletedToBool, usedTime: [] },
+        },
+        { new: true }
+      );
       return checkCompleteSchedule;
     }
   } catch (error) {
@@ -151,11 +151,14 @@ const deleteTime = async (
     const deleteScheduleTime = await Schedule.findById(scheduleId);
     if (!deleteScheduleTime) {
       return null;
-    } else{
+    } else {
       await Schedule.findByIdAndUpdate(
         scheduleId,
         {
-          $pull: { estimatedTime: { $in: timeDto.timeBlockNumbers } , usedTime: { $in: timeDto.timeBlockNumbers } },
+          $pull: {
+            estimatedTime: { $in: timeDto.timeBlockNumbers },
+            usedTime: { $in: timeDto.timeBlockNumbers },
+          },
         },
         {
           new: true,
@@ -267,7 +270,7 @@ const getReschedules = async (
   try {
     const delaySchedules = await Schedule.find({
       userId: userId,
-      subSchedules: { $exists: true, $not: { $size: 0 }},
+      subSchedules: { $exists: true, $not: { $size: 0 } },
       isReschedule: true,
     }).sort({ orderIndex: 1 });
 
@@ -365,7 +368,7 @@ const getRoutines = async (userId: string): Promise<ScheduleListGetDto> => {
   try {
     const routines = await Schedule.find({
       userId: userId,
-      subSchedules: { $exists: true, $not: { $size: 0 }},
+      subSchedules: { $exists: true, $not: { $size: 0 } },
       isRoutine: true,
     }).sort({ orderIndex: 1 });
 
@@ -620,7 +623,7 @@ const updateSchedule = async (
     let existingSubSchedules = await Promise.all(
       existingSchedule.subSchedules.map((existingSubSchedule: any) => {
         const result = {
-          date: '',
+          date: existingSchedule.title,
           title: existingSubSchedule.title,
           categoryColorCode: existingSubSchedule.categoryColorCode,
           userId: existingSubSchedule.userId,
@@ -643,7 +646,7 @@ const updateSchedule = async (
         if (!newSubSchedule.scheduleId) {
           // id가 존재하지 않는 경우 : 새로 생성할 하위 계획 : 새로운 계획 생성 및 id 배열에 push
           const scheduleCreateDto: ScheduleCreateDto = {
-            date: '',
+            date: 'subSchedule',
             title: newSubSchedule.title,
             categoryColorCode: scheduleUpdateDto.categoryColorCode!,
             userId: existingSchedule.userId.toString(),

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -270,7 +270,7 @@ const getReschedules = async (
   try {
     const delaySchedules = await Schedule.find({
       userId: userId,
-      subSchedules: { $exists: true, $not: { $size: 0 } },
+      date: { $ne: 'subSchedule' },
       isReschedule: true,
     }).sort({ orderIndex: 1 });
 


### PR DESCRIPTION
## Solved Issue
close #154 

<br>

## Motivation
- 현재 미룬 계획블록 조회, 자주 사용하는 계획블록 조회 API에서 상위 계획블록과 하위 계획블록이 구별되지 않는 문제가 존재함
- 현 로직에서 하위 계획블록임을 판별하기 위해 특정 계획블록의 subSchedules 배열의 길이를 활용하고 있음
- 이를 해결하기 위해, 임시로 하위 계획블록의 date를 하위 계획 판별을 위한 flag로 수정하려고 함

<br>

## Key Changes
- 하위 계획블록 생성 시 date에 flag로 사용할 string 삽입
- 자주 사용하는 계획블록 조회 시 find 조건에 subSchedule flag 적용
- 미룬 계획블록 조회 시 find 조건에 subSchedule flag 적용

<br>

## To Reviewers
- 확인 후 이상 없으면 바로 머지해주세요!
